### PR TITLE
Addresses #24

### DIFF
--- a/tests/testthat/test-handle_errors.R
+++ b/tests/testthat/test-handle_errors.R
@@ -11,7 +11,7 @@ error_url <- list(
   noRecordsMatch=paste0("http://oai.datacite.org/oai?verb=ListIdentifiers&from=",
                         tomorrow, "&until=", tomorrow, "&metadataPrefix=oai_dc"),
   noMetadataFormats=NULL,
-  noSetHierarchy="https://pbn.nauka.gov.pl/OAI-PMH?verb=ListSets"
+  noSetHierarchy=NULL    # "https://pbn.nauka.gov.pl/OAI-PMH?verb=ListSets"
 )
 
 # GET and parse
@@ -80,10 +80,13 @@ test_that("noRecordsMatch is triggered", {
 test_that("noSetHierarchy is triggered", {
   skip_on_cran()
 
-  xml <- gnp(error_url$noSetHierarchy)
-  expect_error( handle_errors(xml) )
-  expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
-  expect_true( tryCatch( handle_errors(xml), error=function(er) "noSetHierarchy" %in% attr(er, "error_codes")))
+  if( !is.null(error_url$noSetHierarchy) ) {
+    xml <- gnp(error_url$noSetHierarchy)
+    expect_error( handle_errors(xml) )
+    expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
+    expect_true( tryCatch( handle_errors(xml), error=function(er) "noSetHierarchy" %in% attr(er, "error_codes")))
+  }
+
 } )
 
 

--- a/tests/testthat/test-handle_errors.R
+++ b/tests/testthat/test-handle_errors.R
@@ -6,7 +6,7 @@ error_url <- list(
   badArgument="http://arXiv.org/oai2?verb=ListRecords&metadataPrefix=oai_dc&foo=bar",
   badResumptionToken="http://oai.datacite.org/oai?verb=ListRecords&resumptionToken=foobar",
   badVerb="http://arXiv.org/oai2?verb=someverb",
-  cannotDisseminateFormat="https://pbn.nauka.gov.pl/OAI-PMH?verb=GetRecord&identifier=3&metadataPrefix=oai_dc",
+  cannotDisseminateFormat="http://oai.datacite.org/oai?verb=GetRecord&metadataPrefix=foobar&identifier=oai:oai.datacite.org:32255",
   idDoesNotExist="http://arXiv.org/oai2?verb=GetRecord&identifier=foobar&metadataPrefix=oai_dc",
   noRecordsMatch=paste0("http://oai.datacite.org/oai?verb=ListIdentifiers&from=",
                         tomorrow, "&until=", tomorrow, "&metadataPrefix=oai_dc"),


### PR DESCRIPTION
Test failed because of the test URLs used an OAI-PMH service which is down at this moment. I have

1. Replaced the URL for one test.
2. Temporarily turned-off the second test because was not able to find OAI-PMH service with no set hierarchy. It is enough to replace the `NULL` in `error_url$noSetHierarchy` with a proper URL.