### PR TITLE
Use xml2::xml_find_first() instead of deprecated xml2::xml_find_one()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,5 @@ Suggests:
     RSQLite,
     testthat,
     covr
+Remotes: hadley/xml2
 RoxygenNote: 5.0.1

--- a/R/handle_errors.R
+++ b/R/handle_errors.R
@@ -18,7 +18,7 @@
 
 handle_errors <- function(xml) {
   # find error tags
-  req <- xml2::xml_text(xml2::xml_find_one(xml, ".//*[local-name()='request']" ))
+  req <- xml2::xml_text(xml2::xml_find_first(xml, ".//*[local-name()='request']" ))
   nodeset <- xml2::xml_find_all(xml, ".//*[local-name()='error']")
   # collect error information, if any
   if( length(nodeset) == 0 ) {


### PR DESCRIPTION
The next version of xml2 will be deprecating xml_find_one() in favor of
xml_find_first(). The new function is a drop in replacement for the old, and no
longer issues a warning when more than one result would be returned.

This pull request also adds a `Remotes: hadley/xml2` entry to install the
development version of xml2. Once the new version of xml2 is released (2-4
weeks) this should be removed.