### PR TITLE
Package man page cleanups

### DIFF
--- a/R/oai-package.R
+++ b/R/oai-package.R
@@ -7,7 +7,7 @@
 #' See the OAI-PMH V2 specification at
 #' \url{http://www.openarchives.org/OAI/openarchivesprotocol.html}
 #'
-#' @section oai package details:
+#' @section Implementation details:
 #' oai is built on \code{xml2} and `httr`. In addition, we give back
 #' data.frame's whenever possible to make data comprehension, manipulation,
 #' and visualization easier. We also have functions to fetch a large directory

--- a/R/oai-package.R
+++ b/R/oai-package.R
@@ -1,6 +1,3 @@
-#' oai
-#'
-#' @section Introduction:
 #' oai is an R client to work with OAI-PMH (Open Archives Initiative Protocol
 #' for Metadata Harvesting) services, a protocol developed by the
 #' [Open Archives Initiative](https://en.wikipedia.org/wiki/Open_Archives_Initiative).
@@ -33,17 +30,29 @@
 #'
 #' @name oai-package
 #' @aliases oai
+#' @docType package
+#' @title OAI-PMH Client
+#' @keywords package
+#'
 #' @importFrom httr GET content stop_for_status
 #' @importFrom xml2 read_xml xml_children xml_text as_list xml_attrs
 #' xml_name xml_attr xml_ns
 #' @importFrom plyr rbind.fill
 #' @importFrom stringr str_extract
-#' @docType package
-#' @title OAI-PMH Client
+#'
 #' @author Scott Chamberlain \email{myrmecocystus@@gmail.com}
 #' @author Michal Bojanowski \email{michal2992@@gmail.com}
-#' @keywords package
 NULL
+
+
+
+
+
+
+
+
+
+
 
 #' Metadata providers data.frame.
 #'

--- a/man/oai-package.Rd
+++ b/man/oai-package.Rd
@@ -6,16 +6,11 @@
 \alias{oai}
 \title{OAI-PMH Client}
 \description{
-oai
-}
-\section{Introduction}{
-
 oai is an R client to work with OAI-PMH (Open Archives Initiative Protocol
 for Metadata Harvesting) services, a protocol developed by the
 [Open Archives Initiative](https://en.wikipedia.org/wiki/Open_Archives_Initiative).
 OAI-PMH uses XML data format transported over HTTP.
 }
-
 \section{OAI-PMH Info}{
 
 See the OAI-PMH V2 specification at

--- a/man/oai-package.Rd
+++ b/man/oai-package.Rd
@@ -17,7 +17,7 @@ See the OAI-PMH V2 specification at
 \url{http://www.openarchives.org/OAI/openarchivesprotocol.html}
 }
 
-\section{oai package details}{
+\section{Implementation details}{
 
 oai is built on \code{xml2} and `httr`. In addition, we give back
 data.frame's whenever possible to make data comprehension, manipulation,


### PR DESCRIPTION
In summary

- I removed a section "Introduction". The same paragraph is now in a automatically generated section "Description".
- Grouped Roxygen tags in a more meaningful way.
- Changed section title from "oai package details" to "Implementation details".